### PR TITLE
Add PHP ERP skeleton with basic auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:8.2-apache
+
+# Install common PHP extensions
+RUN docker-php-ext-install mysqli pdo_mysql
+
+# Copy project files into the web root
+COPY . /var/www/html/
+
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# deneme
+# PHP ERP Skeleton
+
+This repository contains a simplified ERP skeleton written in PHP using a basic MVC structure. It provides an example of user authentication with role-based access control and serves as a starting point for adding other modules like product management, orders, sample tracking, fabric tracking, and more.
+
+## Setup
+
+1. Create a MySQL database named `erp_db` (or edit `config/database.php` for custom settings).
+2. Import the initial schema:
+
+```bash
+mysql -u root -p erp_db < database/sql/schema.sql
+```
+
+3. Point your web server's document root to the `public/` directory.
+4. Manually insert a user into the `users` table to log in initially.
+
+## Usage
+
+- `/login` : User login page
+- `/users` : List users (admin only)
+- `/users/create` : Create new user (admin only)
+
+Additional modules and database tables should be implemented following the same pattern in the `app/` directory.

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Controllers;
+
+use Models\User;
+
+class AuthController
+{
+    private $pdo;
+
+    public function __construct($pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function showLogin()
+    {
+        require __DIR__ . '/../Views/login.php';
+    }
+
+    public function login()
+    {
+        $username = $_POST['username'] ?? '';
+        $password = $_POST['password'] ?? '';
+
+        $userModel = new User($this->pdo);
+        $user = $userModel->findByUsername($username);
+        if ($user && password_verify($password, $user['password'])) {
+            $_SESSION['user'] = ['id' => $user['id'], 'role' => $user['role'], 'username' => $user['username']];
+            header('Location: /');
+            exit;
+        }
+        $error = 'Invalid credentials';
+        require __DIR__ . '/../Views/login.php';
+    }
+
+    public function logout()
+    {
+        session_destroy();
+        header('Location: /login');
+    }
+}

--- a/app/Controllers/DashboardController.php
+++ b/app/Controllers/DashboardController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Controllers;
+
+class DashboardController
+{
+    public function index()
+    {
+        if (!isset($_SESSION['user'])) {
+            header('Location: /login');
+            exit;
+        }
+        $user = $_SESSION['user'];
+        require __DIR__ . '/../Views/dashboard.php';
+    }
+}

--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Controllers;
+
+use Models\User;
+
+class UserController
+{
+    private $pdo;
+
+    public function __construct($pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function index()
+    {
+        $this->authorize('admin');
+        $stmt = $this->pdo->query('SELECT id, username, role FROM users');
+        $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        require __DIR__ . '/../Views/users/index.php';
+    }
+
+    public function create()
+    {
+        $this->authorize('admin');
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $data = [
+                'username' => $_POST['username'],
+                'password' => $_POST['password'],
+                'role' => $_POST['role'],
+            ];
+            $userModel = new User($this->pdo);
+            $userModel->create($data);
+            header('Location: /users');
+            return;
+        }
+        require __DIR__ . '/../Views/users/create.php';
+    }
+
+    private function authorize($role)
+    {
+        if (!isset($_SESSION['user']) || $_SESSION['user']['role'] !== $role) {
+            header('HTTP/1.1 403 Forbidden');
+            echo 'Unauthorized';
+            exit;
+        }
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Models;
+
+use PDO;
+
+class User
+{
+    private $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function findByUsername($username)
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM users WHERE username = ?');
+        $stmt->execute([$username]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function create($data)
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO users (username, password, role) VALUES (?, ?, ?)');
+        return $stmt->execute([$data['username'], password_hash($data['password'], PASSWORD_BCRYPT), $data['role']]);
+    }
+}

--- a/app/Views/dashboard.php
+++ b/app/Views/dashboard.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Dashboard</title>
+    <meta charset="utf-8">
+</head>
+<body>
+    <h1>Welcome, <?= htmlspecialchars($user['username']) ?></h1>
+    <p>Your role: <?= htmlspecialchars($user['role']) ?></p>
+    <nav>
+        <a href="/logout">Logout</a>
+        <?php if ($user['role'] === 'admin'): ?>
+            | <a href="/users">Manage Users</a>
+        <?php endif; ?>
+    </nav>
+</body>
+</html>

--- a/app/Views/login.php
+++ b/app/Views/login.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+    <meta charset="utf-8">
+</head>
+<body>
+    <h1>Login</h1>
+    <?php if (!empty($error)): ?>
+        <p style="color:red;"><?= $error ?></p>
+    <?php endif; ?>
+    <form method="POST" action="/login">
+        <label>Username:</label>
+        <input type="text" name="username" required><br>
+        <label>Password:</label>
+        <input type="password" name="password" required><br>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>

--- a/app/Views/users/create.php
+++ b/app/Views/users/create.php
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Create User</title>
+    <meta charset="utf-8">
+</head>
+<body>
+    <h1>Create User</h1>
+    <form method="POST" action="/users/create">
+        <label>Username:</label>
+        <input type="text" name="username" required><br>
+        <label>Password:</label>
+        <input type="password" name="password" required><br>
+        <label>Role:</label>
+        <select name="role">
+            <option value="admin">Admin</option>
+            <option value="muhasebe">Muhasebe</option>
+            <option value="modelhane">Modelhane</option>
+            <option value="dikimhane">Dikimhane</option>
+            <option value="patron">Patron</option>
+        </select><br>
+        <button type="submit">Create</button>
+    </form>
+    <a href="/users">Back</a>
+</body>
+</html>

--- a/app/Views/users/index.php
+++ b/app/Views/users/index.php
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Users</title>
+    <meta charset="utf-8">
+</head>
+<body>
+    <h1>User List</h1>
+    <a href="/users/create">Create User</a> | <a href="/">Back</a>
+    <table border="1" cellpadding="5">
+        <tr><th>ID</th><th>Username</th><th>Role</th></tr>
+        <?php foreach ($users as $u): ?>
+            <tr>
+                <td><?= $u['id'] ?></td>
+                <td><?= htmlspecialchars($u['username']) ?></td>
+                <td><?= htmlspecialchars($u['role']) ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+</body>
+</html>

--- a/app/init.php
+++ b/app/init.php
@@ -1,0 +1,26 @@
+<?php
+
+// Autoloader
+spl_autoload_register(function ($class) {
+    $path = __DIR__ . '/' . str_replace('\\', '/', $class) . '.php';
+    if (file_exists($path)) {
+        require $path;
+    }
+});
+
+// Database connection
+$config = require __DIR__ . '/../config/database.php';
+$dsn = "mysql:host={$config['host']};dbname={$config['dbname']};charset={$config['charset']}";
+
+try {
+    $pdo = new PDO($dsn, $config['user'], $config['pass']);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (PDOException $e) {
+    die('Database connection failed: ' . $e->getMessage());
+}
+
+// Simple session
+session_start();
+
+// Global container
+$GLOBALS['pdo'] = $pdo;

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,9 @@
+<?php
+// Simple database connection using PDO
+return [
+    'host' => 'localhost',
+    'dbname' => 'erp_db',
+    'user' => 'root',
+    'pass' => 'password',
+    'charset' => 'utf8mb4',
+];

--- a/database/sql/schema.sql
+++ b/database/sql/schema.sql
@@ -1,0 +1,9 @@
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(100) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role VARCHAR(50) NOT NULL
+);
+
+-- Other tables will be added for modules such as products, orders, fabrics, etc.

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,35 @@
+<?php
+require __DIR__ . '/../app/init.php';
+
+use Controllers\AuthController;
+use Controllers\DashboardController;
+use Controllers\UserController;
+
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
+$auth = new AuthController($pdo);
+$dashboard = new DashboardController();
+$userController = new UserController($pdo);
+
+switch ($path) {
+    case '/login':
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $auth->login();
+        } else {
+            $auth->showLogin();
+        }
+        break;
+    case '/logout':
+        $auth->logout();
+        break;
+    case '/users/create':
+        $userController->create();
+        break;
+    case '/users':
+        $userController->index();
+        break;
+    case '/':
+    default:
+        $dashboard->index();
+        break;
+}


### PR DESCRIPTION
## Summary
- start PHP MVC-style skeleton
- implement database config and connection
- add basic login/logout and admin user management
- create minimal views and SQL schema

## Testing
- `php -l public/index.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684917e46db88320a3e6f5a0a1a839cc